### PR TITLE
Sorting out legal properties 

### DIFF
--- a/acdh-schema.owl
+++ b/acdh-schema.owl
@@ -604,6 +604,8 @@ This is a generic property. Use one of the more specific subproperties where pos
         <acdh:ordering rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">74</acdh:ordering>
     </owl:ObjectProperty>
     
+
+
     <!-- https://vocabs.acdh.oeaw.ac.at/schema#hasEnabler -->
 
     <owl:ObjectProperty rdf:about="https://vocabs.acdh.oeaw.ac.at/schema#hasEnabler">
@@ -616,8 +618,9 @@ This is a generic property. Use one of the more specific subproperties where pos
         <skos:altLabel xml:lang="en">Enabled by</skos:altLabel>
         <skos:altLabel xml:lang="de">Ermöglicht durch</skos:altLabel>
         <acdh:inverse xml:lang="en">is enabler of</acdh:inverse>
-        <acdh:ordering rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">74</acdh:ordering>
+        <acdh:ordering rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">81</acdh:ordering>
     </owl:ObjectProperty>
+    
 
 
     <!-- https://vocabs.acdh.oeaw.ac.at/schema#hasFunder -->
@@ -768,7 +771,7 @@ Handles belong into hasPid and all other identifiers without URL or URI, like lo
         <acdh:exampleValue xml:lang="en">See hasContributor for Person example and hasContact for Organisation.</acdh:exampleValue>
         <acdh:exampleValue xml:lang="de">Siehe hasContributor für ein Beispiel zu Personen und hasContact für ein Beispiel zu Organisationen.</acdh:exampleValue>
         <acdh:inverse xml:lang="en">is metadata creator of</acdh:inverse>
-        <acdh:ordering rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">81</acdh:ordering>
+        <acdh:ordering rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">82</acdh:ordering>
     </owl:ObjectProperty>
     
 
@@ -1647,7 +1650,7 @@ https://www.iana.org/assignments/character-sets/character-sets.xhtml</rdfs:comme
         <rdfs:label xml:lang="en">has custom citation</rdfs:label>
         <skos:altLabel xml:lang="de">Benutzerdefinierte Zitation</skos:altLabel>
         <skos:altLabel xml:lang="en">Custom citation</skos:altLabel>
-        <acdh:ordering rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">82</acdh:ordering>
+        <acdh:ordering rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">89</acdh:ordering>
     </owl:DatatypeProperty>
     
 

--- a/acdh-schema.owl
+++ b/acdh-schema.owl
@@ -2869,6 +2869,18 @@ Die verschiedenen Rollen, die ein Agent in Bezug auf ein Projekt, eine Sammlung,
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasLicensor"/>
+                <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasRightsHolder"/>
+                <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasLicense"/>
                 <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:cardinality>
             </owl:Restriction>
@@ -3593,25 +3605,7 @@ Note that though a Project might (and usually will) use or produce data, it is N
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasLicensor"/>
-                <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
                 <owl:onProperty rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasMetadataCreator"/>
-                <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasOwner"/>
-                <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasRightsHolder"/>
                 <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -3637,6 +3631,13 @@ Note that though a Project might (and usually will) use or produce data, it is N
             <owl:Restriction>
                 <owl:onProperty rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasMetadataPid"/>
                 <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasRightsInformation"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -3765,6 +3766,12 @@ Note that though a Project might (and usually will) use or produce data, it is N
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasCurator"/>
+                <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasEditor"/>
                 <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>

--- a/acdh-schema.owl
+++ b/acdh-schema.owl
@@ -19,178 +19,8 @@ When Definitionen aus anderen Schemata (z. B. DataCite) wiederverwendet werden, 
 In definitions of properties, &quot;resource A&quot; refers to the subject resource of the property and &quot;resource B&quot; to the object resource.
 When reusing definitions from other vocabularies (esp. DataCite), the reference is given in brackets: (DataCite: ContactPerson). When the source definition was changed slightly the reference is marked with &quot;cf.&quot;</rdfs:comment>
         <rdfs:label>ARCHE Schema</rdfs:label>
-        <owl:versionInfo xml:lang="en">Version 1.0 released on 2017-11-03.</owl:versionInfo>
-        <owl:versionInfo xml:lang="de">Version 1.0. veröffentlicht am 2017-11-03.</owl:versionInfo>
-        <owl:versionInfo xml:lang="en">Version 1.1 released on 2018-01-15.
-Changed achd:language to acdh:hasLanguage.
-Removed acdh:hasIssuedDate.
-Introduced link to controlled vocabularies for datatype properties via annotation property acdh:vocabs.
-Transformed some object properties into datatype properties (hasAccessRestriction, hasCategory, hasLifeCycleStatus) to link with controlled vocabulary.</owl:versionInfo>
-        <owl:versionInfo xml:lang="de">Version 1.1 veröffentlicht am 2018-01-15.
-Name von achd:language auf acdh:hasLanguage geändert.
-achd:hasIssuedDate wurde entfernt.
-Link auf kontrollierte Vokabulare für datatype properties mittels der annotation property acdh:vocabs eingefügt.
-Einige object properties (hasAccessRestriction, hasCategory, hasLifeCycleStatus) wurden in datatype properties umgewandelt, um sie auf kontrollierte Vokabulare zu verlinken.</owl:versionInfo>
-        <owl:versionInfo xml:lang="en">Version 1.2 released on 2018-06-11.
-Removed hasCopyrightedDate, hasValidEndDate, hasValidStartDate, cites, compiles, isAppliedMethod, isCitedBy, isCompiledBy, isDerivedFrom, isFormat, isIdenticalTo, isLicense, isOriginalFormOf, isReferencedBy, isRelatedDiscipline, isReviewedBy, isSchema, isSubject, isSupplementTo, isSupplementedBy, isTransferMethod, isVariantFormOf, references, and reviews.
-
-Introduced hasRestrictionRole and hasTemporalCoverageIdentifier.
-
-Transformed further object properties into datatype properties (hasSchema, hasTransferMethod, hasSubject, hasRelatedDiscipline, hasLicense, hasFormat, hasAppliedMethod).
-
-Renamed several properties starting with is... to is...Of to indicate direction of relation. Also renamed hasEndpoint to hasLandingPage.
-
-Introduced Helper classes to avoid anonymous class unions. Added domains and ranges to all properties accordingly.
-
-Introduced annotation property acdh:ordering to indicate how properties should be ordered when displayed in a form.
-
-Introduced annotation property acdh:recommendedClass to indicate in which class a property is recommended, but not mandatory.</owl:versionInfo>
-        <owl:versionInfo xml:lang="de">Version 1.2 veröffentlicht am 2018-06-11.
-Weitere object properties wurden entfernt: hasCopyrightedDate, hasValidEndDate, hasValidStartDate, cites, compiles, isAppliedMethod, isCitedBy, isCompiledBy, isDerivedFrom, isFormat, isIdenticalTo, isLicense, isOriginalFormOf, isReferencedBy, isRelatedDiscipline, isReviewedBy, isSchema, isSubject, isSupplementTo, isSupplementedBy, isTransferMethod, isVariantFormOf, references und reviews.
-
-Neu sind: hasRestrictionRole und hasTemporalCoverageIdentifier.
-
-Weitere object properties wurden in datatype properties umgewandelt (hasSchema, hasTransferMethod, hasSubject, hasRelatedDiscipline, hasLicense, hasFormat, hasAppliedMethod).
-
-Umbenennung von properties, die mit is... anfangen in is...Of, um die richtung der Relation deutlicher anzuzeigen. Außerdem wurde hasEndpoint in hasLandingPage umbenannt.
-
-Helper Klassen wurden eingeführt, um anonyme Vereinigungen von Klassen zu vermeiden. Domains und ranges wurden für alle properties gesetzt.
-
-Die annotation property acdh:ordering wurde eingeführt, um anzuzeigen in welcher Reihenfolge properties in einem Formular angezeigt werden sollten.
-
-Die annotation annotation property acdh:recommendedClass wurde eingeführt, um anzuzeigen in welcher Klasse eine property empfohlen, aber nicht verpflichtend ist.</owl:versionInfo>
-        <owl:versionInfo xml:lang="en">Version 1.3 released on 2019-09-12.
-Added missing range to acdh:hasAppliedMethod
-
-Added link to controlled vocabulary for acdh:hasRelatedDiscipline
-Added link to controlled vocabulary for acdh:hasLanguage
-
-Introduced new property acdh:hasOaiSet
-
-Increased set of mandatory properties
-Added and corrected English and German descriptions for all properties.</owl:versionInfo>
-        <owl:versionInfo xml:lang="de">Version 1.3 veröffentlicht am 2019-09-12.
-Fehlende range-Angabe an acdh:hasAppliedMethod hinzugefügt
-
-Link auf kontrolliertes Vokabular hinzugefügt für acdh:hasRelatedDiscipline
-Link auf kontrolliertes Vokabular hinzugefügt für acdh:hasLanguage
-
-Neues Attribut hinzugefügt: acdh:hasOaiSet
-
-Set von verpflichtenden Attributen erhöht.
-Englische und Deutsche Beschreibungen für alle Attribute hinzugefügt und korrigiert.</owl:versionInfo>
-        <owl:versionInfo xml:lang="en">Version 1.4 released on 2019-12-05.
-hasLastName no longer required for class Person, but hasTitle is.</owl:versionInfo>
-        <owl:versionInfo xml:lang="de">Version 1.4 veröffentlicht am 2019-12-05.
-hasLastName ist nicht mehr verpflichtend für die Klasse Person, aber hasTitle ist es.</owl:versionInfo>
-        <owl:versionInfo xml:lang="en">Version 1.5 released on 2020-02-29.
-New property acdh:hasOaiSet with range xsd:string. Terms should come from vocabulary indicated in acdh:vocabs
-Introduced annotation property acdh:langTag with range xsd:boolean. It is set to true for properties where a language tag is mandatory.</owl:versionInfo>
-        <owl:versionInfo xml:lang="de">Version 1.5 veröffentlicht am 2019-02-29.
-Neues attribut acdh:hasOaiSet mit range xsd:string eingeführt. Begriffe sollen aus dem mit acdh:vocabs angegebenen Vokabular verwendet werden.
-Die annotation property acdh:langTag wurde eingeführt. Sie hat den range xsd:boolean. Sie wurde mit dem Wert &apos;true&apos; für alle attribute gesetzt, in denen Sprachmarker verpflichtend sind.</owl:versionInfo>
-        <owl:versionInfo xml:lang="en">Version 1.6 released on 2020-02-29.
-Introduced vocabulary for acdh:hasLicense</owl:versionInfo>
-        <owl:versionInfo xml:lang="de">Version 1.6 veröffentlicht am 2019-02-29.
-Vokabular für acdh:hasLicense eingefügt.</owl:versionInfo>
-        <owl:versionInfo xml:lang="en">Version 1.7 released on 2020-05-08.
-acdh:vocabs annotation property values adjusted to point to endpoints providing actual vocabulary data (instead of a WWW GUI). This is necessary for tools to make use of the acdh:vocabs annotation property.</owl:versionInfo>
-        <owl:versionInfo xml:lang="en">Version 1.8 released on 2020-07-07.
-Change type of hasLanguage to xsd:anyURI.
-Introduced helper class CollectionOrImageorResource.
-Introducted hasDigitisingAgent, hasLicenseSummary, hasAccessRestrictionSummary.</owl:versionInfo>
-        <owl:versionInfo xml:lang="en">Version 1.9 released on 2020-07-16.
-Added annotation properties acdh:automatedFill and acdh:defaultValue.
-Introduced helper class ImageorResource.
-Introduced hasCreatedDateOriginal.</owl:versionInfo>
-        <owl:versionInfo xml:lang="en">Version 2.0 released on 2021-02-15.
-An overhauled version of the ontology with many small and some bigger changes, including updates of class and property definitions and translations.
-
-Changed Datatype Properties to Object Properties with range skos:Concept (acdh:hasAccessRestriction, acdh:hasCategory, acdh:hasLanguage, acdh:hasLicense, acdh:hasLifeCycleStatus, acdh:hasRelatedDiscipline, acdh:hasOAISet).
-Introduced class acdh:TopCollection.
-Removed class acdh:Image, acdh:ImageOrResource, and acdh:CollectionOrImageorResource.
-Introduced technical properties.
-Introduced acdh:hasIssuedDate with domain acdh:Publication.
-Introduced acdh:hasCreatedStartDateOriginal and acdh:hasCreatedEndDateOriginal.
-Introduced acdh:hasVersionInfo.
-Introduced acdh:hasMetadataPid.
-Removed acdh:hasLandingPage, acdh:hasCreatedDate, and acdh:hasCreatedDateOriginal from the ontology.
-
-Removed inverse properties (acdh:isActorOf, acdh:isAuthorOf, acdh:isContactOf, acdh:isContributorOf, acdh:isCoverageOf, acdh:isCreatorOf, acdh:isCuratorOf, acdh:isDepositorOf, acdh:isEditorOf, acdh:isFunderOf, acdh:isHostingOf, acdh:isLicensorOf, acdh:isDigitisingAgentOf, acdh:isMetadataCreatorOf, acdh:isOwnerOf, acdh:isPrincipalInvestigatorOf, acdh:isRightsHolderOf, acdh:isSpatialCoverageOf, acdh:hasMember, acdh:hasPart, acdh:hasSource, acdh:hasTitleImage, acdh:hasMetadata, acdh:isDocumentedBy, acdh:isContinuedBy, acdh:hasDerivedPublication).
-Changed cardinality for acdh:hasLicense for acdh:Collection to 0-1.
-Changed domain for acdh:hasCompleteness and acdh:hasNumberOfItems (to exclude acdh:Resource).
-Extended domain of acdh:hasTableOfContents to acdh:Resources.
-Extended domain of acdh:hasAvailableDate and hasAccessRestriction to owl:Thing.
-
-Introduced annotation acdh:inverse indicating the label of inverse relation of a property.
-Introduced annotation acdh:automatedfill to acdh:hasLocationPath.</owl:versionInfo>
-        <owl:versionInfo xml:lang="de">Version 2.0 veröffentlicht am 2021-02-15.
-Eine gründlich überarbeitete Version der Ontologie mit vielen kleinen und eineigen größeren Anpassungen, inklusive Aktualisierung der Beschreibungen und Übersetzungen von Klassen und Eigenschaften.
-
-Einige Datatype Properties wurden in Object Properties mit range skos:Concept umgewandelt (acdh:hasAccessRestriction, acdh:hasCategory, acdh:hasLanguage, acdh:hasLicense, acdh:hasLifeCycleStatus, acdh:hasRelatedDiscipline, acdh:hasOAISet).
-Klase acdh:TopCollection eingefügt.
-Klassen acdh:Image, acdh:ImageOrResource, und acdh:CollectionOrImageorResource enfernt.
-Technische Eigenschaften eingefügt.
-acdh:hasIssuedDate mit domain acdh:Publication eingefügt.
-acdh:hasCreatedStartDateOriginal und acdh:hasCreatedEndDateOriginal eingefügt.
-acdh:hasVersionInfo eingefügt.
-acdh:hasMetadataPid eingefügt.
-acdh:hasLandingPage, acdh:hasCreatedDate, und acdh:hasCreatedDateOriginal entfernt.
-
-Inverse Eigenschaften wurden entfernt (acdh:isActorOf, acdh:isAuthorOf, acdh:isContactOf, acdh:isContributorOf, acdh:isCoverageOf, acdh:isCreatorOf, acdh:isCuratorOf, acdh:isDepositorOf, acdh:isEditorOf, acdh:isFunderOf, acdh:isHostingOf, acdh:isLicensorOf, acdh:isDigitisingAgentOf, acdh:isMetadataCreatorOf, acdh:isOwnerOf, acdh:isPrincipalInvestigatorOf, acdh:isRightsHolderOf, acdh:isSpatialCoverageOf, acdh:hasMember, acdh:hasPart, acdh:hasSource, acdh:hasTitleImage, acdh:hasMetadata, acdh:isDocumentedBy, acdh:isContinuedBy, acdh:hasDerivedPublication).
-Kardinalität von acdh:hasLicense für acdh:Collection zu 0-1 geändert.
-Domain für acdh:hasCompleteness und acdh:hasNumberOfItems geändert (um acdh:Resource auszunehmen).
-Domain von acdh:hasTableOfContents zu acdh:Resources geändert.
-Domain von acdh:hasAvailableDate und hasAccessRestriction auf owl:Thing ausgeweitet.
-
-Annotation acdh:inverse eingefügt, welche die Beschriftung der inversen Relation einer Eigenschaft angibt.
-Annotation acdh:automatedfill für acdh:hasLocationPath eingefügt.</owl:versionInfo>
-        <owl:versionInfo xml:lang="en">Version 3.0 released on 2022-01-31.
-Introduced acdh:hasTag with domain owl:Thing.
-Renamed acdh:isDerivedPublication to acdh:isDerivedPublicationOf
-
-Changed domain for acdh:hasFilename (to include acdh:Collection and acdh:TopCollection).
-
-Changed cardinality for acdh:isTitleImageOf for acdh:Resource to 0-n to allow multiple uses of images.
-Changed cardinality for acdh:hasCategory for acdh:BinaryContent to 0-n to allow multiple assignement of categories.</owl:versionInfo>
-        <owl:versionInfo xml:lang="de">Version 3.0 veröffentlicht am 2022-01-31.
-acdh:hasTag mit domain owl:Thing eingefügt.
-Umbenennung von acdh:isDerivedPublication zu acdh:isDerivedPublicationOf
-
-Domain für acdh:hasFilename geändert (um acdh:Collection und acdh:TopCollection zu inkludieren).
-
-Kardinalität von acdh:isTitleImageOf für acdh:Resource geändert zu 0-n, um die mehrfache Nutzung von Bildern zu erlauben.
-Kardinalität von acdh:hasCategory für acdh:BinaryContent gändert zu 0-n, um mehrere Kategorien zu erlauben.</owl:versionInfo>
-        <owl:versionInfo xml:lang="en">Version 4.0 released on 2023-12-22.
-Renamed to ARCHE Schema (was ACDH Schema before)
-Introduced annotation property acdh:exampleValue to allow for the inclusion of example values.
-Introduced acdh:hasNextItem with domain acdh:RepoObject.
-Introduced acdh:hasIiifManifest with domain acdh:BinaryContent.
-Introduced acdh:hasRightsInfomation with domain acdh:RepoObject.
-Expanded description for acdh:hasOaiSet to include visibility in OpenAIRE.
-
-Dropped acdh:hasLocationPath as it wasn&apos;t technically required anymore.
-
-Added acdh:automatedFill &apos;true&apos; to acdh:disseminationServices.
-Added acdh:automatedFill &apos;true&apos; to acdh:technical.
-Changed range for acdh:hasLatitude to float.
-Changed range for acdh:hasLongitude to float.
-Changed range for acdh:hasRawBinarySize to positiveInteger.</owl:versionInfo>
-        <owl:versionInfo xml:lang="de">Version 4.0 veröffentlicht am 2023-12-22.
-Umbenannt zu ARCHE Schema (war vorher ACDH Schema)
-Annotation property acdh:exampleValue zur Eingabe von Beispielwerten eingefügt.
-acdh:hasNextItem mit domain acdh:RepoObject eingefügt.
-acdh:hasIiifManifest mit domain acdh:BinaryContent eingefügt.
-acdh:hasRightsInfomation mit domain acdh:RepoObject.
-Beschreibung von acdh:hasOaiSet erweitert, um die Sichtbarkeit in OpenAIRE zu berücksichtigen.
-
-acdh:hasLocationPath entfernt, da diese Eigenschaft technisch nicht mehr benötigt wird.
-
-acdh:automatedFill &apos;true&apos; für acdh:disseminationServices eingefügt.
-acdh:automatedFill &apos;true&apos; für acdh:technical eingefügt.
-Range für acdh:hasLatitude zu float geändert.
-Range für acdh:hasLongitude zu float geändert.
-Range für acdh:hasRawBinarySize zu positiveInteger geändert.</owl:versionInfo>
+        <owl:versionInfo xml:lang="en">Version 1.0 of the ontology was released on 2017-11-03. The current version number and the changes applied are documented in the Release notes on GitHub: https://github.com/acdh-oeaw/arche-schema/releases</owl:versionInfo>
+        <owl:versionInfo xml:lang="de">Version 1.0. der Ontologie wurde veröffentlicht am 2017-11-03. Die aktuelle Versionsnummer und die vorgenommenen Änderungen sind in den Release Notes auf GitHub dokumentiert:  https://github.com/acdh-oeaw/arche-schema/releases</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -612,8 +442,10 @@ This is a generic property. Use one of the more specific subproperties where pos
         <rdfs:subPropertyOf rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasContributor"/>
         <rdfs:domain rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#CollectionOrReMeOrPublication"/>
         <rdfs:range rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#Agent"/>
-        <rdfs:comment xml:lang="en">A Person or Organisation (B) that enabled the xxto happen.</rdfs:comment>
-        <rdfs:comment xml:lang="de">Eine Person oder Organisation (B), xxx.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A person or organisation (B) that facilitates resource creation through indirect support, such as providing access to infrastructure, data, specialised equipment, granting permissions, or institutional backing, without active participation in the project&apos;s execution. Examples include the host institution of a project and the institution that provided data (e.g. an archive).
+The property &apos;hasFunder&apos; should be used for financial contributions.</rdfs:comment>
+        <rdfs:comment xml:lang="de">Eine Person oder Organisation (B), die die Erstellung von Ressourcen durch indirekte Unterstützung ermöglicht, z. B. durch die Bereitstellung von Infrastruktur, Daten, Spezialausrüstung, die Erteilung von Genehmigungen oder institutionelle Unterstützung, ohne sich aktiv an der Durchführung des Projekts zu beteiligen. Beispiele sind die Gastinstitution eines Projekts und die Institution, die Daten zur Verfügung stellt (z. B. ein Archiv).
+Die Eigenschaft „hasFunder“ sollte für finanzielle Beiträge verwendet werden.</rdfs:comment>
         <rdfs:label xml:lang="en">has enabler</rdfs:label>
         <skos:altLabel xml:lang="en">Enabled by</skos:altLabel>
         <skos:altLabel xml:lang="de">Ermöglicht durch</skos:altLabel>
@@ -629,8 +461,8 @@ This is a generic property. Use one of the more specific subproperties where pos
         <rdfs:subPropertyOf rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasContributor"/>
         <rdfs:domain rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#ContainerOrReMe"/>
         <rdfs:range rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#Agent"/>
-        <rdfs:comment xml:lang="de">Person oder Organisation (B), die ein Projekt (A) finanziert hat. Person oder Organisation, die einen Vertrag abgeschlossen hat oder unter deren Schirmherrschaft ein Werk geschrieben, gedruckt, veröffentlicht, entwickelt usw. wurde. (vgl. DataCite: Sponsor)</rdfs:comment>
-        <rdfs:comment xml:lang="en">Person or Organisation (B) which provided funding for a project (A). Person or organisation that issued a contract or under the auspices of which a work has been written, printed, published, developed, etc. (cf. DataCite: Sponsor)</rdfs:comment>
+        <rdfs:comment xml:lang="de">Person oder Organisation (B), die ein Projekt (A) finanziert hat, z. B. durch finanzielles Sponsoring oder monetäre Beiträge.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Person or Organisation (B) which provided funding, e.g. financial sponsorship or monetry contributions, for a project (A).</rdfs:comment>
         <rdfs:label xml:lang="en">has funder</rdfs:label>
         <skos:altLabel xml:lang="en">Funder(s)</skos:altLabel>
         <skos:altLabel xml:lang="de">Geldgeber</skos:altLabel>

--- a/acdh-schema.owl
+++ b/acdh-schema.owl
@@ -3636,8 +3636,7 @@ Note that though a Project might (and usually will) use or produce data, it is N
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasRightsInformation"/>
-                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
-                <owl:onDataRange rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+                <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>

--- a/acdh-schema.owl
+++ b/acdh-schema.owl
@@ -595,8 +595,8 @@ This is a generic property. Use one of the more specific subproperties where pos
         <rdfs:subPropertyOf rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasContributor"/>
         <rdfs:domain rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#CollectionOrReMeOrPublication"/>
         <rdfs:range rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#Agent"/>
-        <rdfs:comment xml:lang="en">A person who oversees the details related to the publication format of the resource. (cf. DataCite: Editor)</rdfs:comment>
-        <rdfs:comment xml:lang="de">Eine Person, die sich mit den Details des Publikationsformats der Ressource befasst. (vgl. DataCite: Editor)</rdfs:comment>
+        <rdfs:comment xml:lang="en">A Person or Organisation (B) responsible for selecting, arranging, and ensuring that the resources (A) comply with the submission requirements of ARCHE. The Editor is the Person to whom the entire data collection is attributed, analogous to the editor of an edited volume and may also be used in this sense for a Publication.</rdfs:comment>
+        <rdfs:comment xml:lang="de">Eine Person oder Organisation (B), die für die Auswahl, Zusammenstellung und Sicherstellung der Konformität der Ressourcen (A) mit den Einreichungsanforderungen von ARCHE verantwortlich ist. Der Herausgeber ist die Person, der die gesamte Datensammlung zugeschrieben wird, analog zum Herausgeber eines Sammelbandes, und kann in diesem Sinne auch für eine Publikation  verwendet werden.</rdfs:comment>
         <rdfs:label xml:lang="en">has editor</rdfs:label>
         <skos:altLabel xml:lang="en">Editor(s)</skos:altLabel>
         <skos:altLabel xml:lang="de">Herausgeber</skos:altLabel>
@@ -604,6 +604,20 @@ This is a generic property. Use one of the more specific subproperties where pos
         <acdh:ordering rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">74</acdh:ordering>
     </owl:ObjectProperty>
     
+    <!-- https://vocabs.acdh.oeaw.ac.at/schema#hasEnabler -->
+
+    <owl:ObjectProperty rdf:about="https://vocabs.acdh.oeaw.ac.at/schema#hasEnabler">
+        <rdfs:subPropertyOf rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasContributor"/>
+        <rdfs:domain rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#CollectionOrReMeOrPublication"/>
+        <rdfs:range rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#Agent"/>
+        <rdfs:comment xml:lang="en">A Person or Organisation (B) that enabled the xxto happen.</rdfs:comment>
+        <rdfs:comment xml:lang="de">Eine Person oder Organisation (B), xxx.</rdfs:comment>
+        <rdfs:label xml:lang="en">has enabler</rdfs:label>
+        <skos:altLabel xml:lang="en">Enabled by</skos:altLabel>
+        <skos:altLabel xml:lang="de">Ermöglicht durch</skos:altLabel>
+        <acdh:inverse xml:lang="en">is enabler of</acdh:inverse>
+        <acdh:ordering rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">74</acdh:ordering>
+    </owl:ObjectProperty>
 
 
     <!-- https://vocabs.acdh.oeaw.ac.at/schema#hasFunder -->
@@ -1829,7 +1843,7 @@ https://www.iana.org/assignments/character-sets/character-sets.xhtml</rdfs:comme
     <!-- https://vocabs.acdh.oeaw.ac.at/schema#hasFunderLogo -->
 
     <owl:DatatypeProperty rdf:about="https://vocabs.acdh.oeaw.ac.at/schema#hasFunderLogo">
-        <rdfs:domain rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#Container"/>
+        <rdfs:domain rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#ContainerOrReMe"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
         <rdfs:comment xml:lang="de">Logo (B) einer Person oder Organisation, die ein Projekt (A) finanziert hat. Das Logo wird als Datei im Format SVG oder PNG unter https://shared.acdh.oeaw.ac.at/arche-funder-logos/ abgelegt. Mittels URL wird auf die Datei referenziert.</rdfs:comment>
         <rdfs:comment xml:lang="en">Logo (B) of a Person or Organisation, which provided funding for a project (A). The logo is stored as a file in SVG or PNG format at https://shared.acdh.oeaw.ac.at/arche-funder-logos/. The file is referenced via URL.</rdfs:comment>


### PR DESCRIPTION
With this branch we can adjust our ontology to come a bit nearer to sorting out legal properties in ARCHE

- [x] change definition of hasEditor
- [x] change cardinality of hasEditor to 1-n for TopCollection
- [x] change cardinality of hasOwner, hasLicensor and, hasRightsHolder to 0-n for Collection and TopCollection
- [x] change cardinality of hasRightsInformation to 0-1 for ~~BinaryObject~~ RepoObject
- [x] introduce the new property hasEnabler
- [x] add a definition for hasEnabler
- [x] update definition of hasFunder to match our current practice
- [x] adjust ordering of hasMetadataCreator and hasCustomCitation